### PR TITLE
feat: support custom endpoint configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -127,8 +127,11 @@ resource "aws_elasticsearch_domain" "default" {
   }
 
   domain_endpoint_options {
-    enforce_https       = var.domain_endpoint_options_enforce_https
-    tls_security_policy = var.domain_endpoint_options_tls_security_policy
+    enforce_https                   = var.domain_endpoint_options_enforce_https
+    tls_security_policy             = var.domain_endpoint_options_tls_security_policy
+    custom_endpoint_enabled         = var.custom_endpoint_enabled
+    custom_endpoint                 = var.custom_endpoint_enabled ? var.custom_endpoint : null
+    custom_endpoint_certificate_arn = var.custom_endpoint_enabled ? var.custom_endpoint_certificate_arn : null
   }
 
   cluster_config {

--- a/variables.tf
+++ b/variables.tf
@@ -333,3 +333,21 @@ variable "advanced_security_options_master_user_password" {
   default     = ""
   description = "Master user password (applicable if advanced_security_options_internal_user_database_enabled set to true)"
 }
+
+variable "custom_endpoint_enabled" {
+  type        = bool
+  description = "Whether to enable custom endpoint for the Elasticsearch domain."
+  default     = false
+}
+
+variable "custom_endpoint" {
+  type        = string
+  description = "Fully qualified domain for custom endpoint."
+  default     = ""
+}
+
+variable "custom_endpoint_certificate_arn" {
+  type        = string
+  description = "ACM certificate ARN for custom endpoint."
+  default     = ""
+}

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.35.0"
     }
     template = {
       source  = "hashicorp/template"


### PR DESCRIPTION
## what
* Adds support of ES custom endpoints since it was shipped in provider in [v0.35](https://github.com/hashicorp/terraform-provider-aws/pull/16192#event-4537309082)

## why
* This allows to get rid of workaround like using null_resource to enable custom endpoint

## references
* https://github.com/hashicorp/terraform-provider-aws/pull/16192#event-4537309082 

